### PR TITLE
Changed selected background text

### DIFF
--- a/aspartate.css
+++ b/aspartate.css
@@ -1,4 +1,10 @@
 :root {
+    /*
+    * Substitute black search background for blue
+    */
+    --select-text-bg-color:#4a89dc;
+    --search-select-bg-color: #428bca;   
+ 
     /**
     * 系统变量
     */


### PR DESCRIPTION
When searching the highlighted text is black, so it is very difficult to find over a dark background.

Instead, use a blue text background.